### PR TITLE
Fixed placeholder label y position

### DIFF
--- a/CSGrowingTextView/CSGrowingTextView/CSGrowingTextView.m
+++ b/CSGrowingTextView/CSGrowingTextView/CSGrowingTextView.m
@@ -157,7 +157,7 @@
 }
 
 - (CGFloat)insetsValue {
-    return self.minimumNumberOfLines * (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1 ? -2.0 : -3.0);
+    return self.minimumNumberOfLines * (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_6_1 ? -2.0 : 0.0);
 }
 
 - (void)updatePlaceholderFrame {


### PR DESCRIPTION
The placeholder label's y position was too high up, causing it not to be centered in the text view. I've changed the offset multiplier to 0 which fixes the position on iOS 7 and iOS 8. I've left the multiplier as-is for versions lower than iOS 6.1 since I'm not able to test versions lower than 6.1.