### PR TITLE
Disable iOS 7 workaround if you are using iOS 9 SDK

### DIFF
--- a/CSGrowingTextView/CSGrowingTextView/CSGrowingTextView.m
+++ b/CSGrowingTextView/CSGrowingTextView/CSGrowingTextView.m
@@ -57,6 +57,9 @@
     _growAnimationDuration = 0.1;
     _growAnimationOptions = UIViewAnimationOptionCurveEaseInOut;
     
+    #ifdef __IPHONE_9_0
+    _internalTextView = [[UITextView alloc] initWithFrame:self.bounds];
+    #else
     // Fix for iOS 7+ jumping text problem
     // Solution based on http://stackoverflow.com/a/19339716/740474
     NSString *reqSysVer = @"7.0";
@@ -73,6 +76,7 @@
     } else {
         _internalTextView = [[UITextView alloc] initWithFrame:self.bounds];
     }
+    #endif
     _internalTextView.font = [UIFont systemFontOfSize:15];
     _internalTextView.autoresizingMask = (UIViewAutoresizingFlexibleWidth |
                                           UIViewAutoresizingFlexibleHeight);


### PR DESCRIPTION
Workaround is not necessary when you are using iOS 9 SDK and in some conditions it leads to problems - if you are typing without new line it will not wrap the text to next line, text will be hidden outside textview frame.

Related to https://github.com/cloverstudio/CSGrowingTextView/pull/7