### PR TITLE
Fixed textViewHeight calculation for iOS 9

### DIFF
--- a/CSGrowingTextView/CSGrowingTextView/CSGrowingTextView.m
+++ b/CSGrowingTextView/CSGrowingTextView/CSGrowingTextView.m
@@ -242,17 +242,8 @@
                       _internalTextView.textContainerInset.top + _internalTextView.textContainerInset.bottom :
                       -iOS6Insets.top + (-iOS6Insets.bottom));
 
-    CGFloat lineHeight = _internalTextView.font.lineHeight;
-    if (lineHeight) {
-        lineHeight = (lineHeight - (NSInteger)lineHeight < 0.5 ?
-                      lineHeight - (lineHeight - (NSInteger)lineHeight) + 0.5 :
-                      ceil(lineHeight));
-        
-        return ceil(lineHeight * lines + insets);
-    }
-    else {
-        return ceil(lineHeight * lines + insets);
-    }
+    CGFloat lineHeight = ceil(_internalTextView.font.lineHeight);
+    return ceil(lineHeight * lines + insets);
 }
 
 #pragma mark - Responders


### PR DESCRIPTION
It seems that on iOS 9 if you round to the nearest 0.5 it won't show the second line of text since it thinks the `UITextView` isn't tall enough. The solution is to just `ceil` the lineHeight before multiplying by the number of lines.